### PR TITLE
Rectify spelling error from Arthors to Authors

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ compinit
 
 > Remember, your fpath configuration need to be set up before you called `compinit`.
 
-## Arthors
+## Authors
 
 * Colin Su - https://github.com/littleq0903
 


### PR DESCRIPTION
Rectify spelling error "Arthors" to "Authors" in README.md 
